### PR TITLE
13 implement oauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,8 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
-
 gem 'faraday'
+gem 'omniauth-google-oauth2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,12 +94,14 @@ GEM
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
+    hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    jwt (2.7.0)
     launchy (2.5.2)
       addressable (~> 2.8)
     listen (3.1.5)
@@ -121,6 +123,7 @@ GEM
     mini_portile2 (2.8.1)
     minitest (5.17.0)
     msgpack (1.6.0)
+    multi_xml (0.6.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -136,6 +139,25 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.1.1)
+      jwt (>= 2.0)
+      oauth2 (~> 2.0.6)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8.0)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     orderly (0.1.1)
       capybara (>= 1.1)
       rspec (>= 2.14)
@@ -151,6 +173,8 @@ GEM
     puma (3.12.6)
     racc (1.6.2)
     rack (2.2.6.2)
+    rack-protection (3.0.5)
+      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (5.2.8.1)
@@ -243,6 +267,9 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -259,6 +286,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.4.2)
+    version_gem (1.1.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -290,6 +318,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  omniauth-google-oauth2
   orderly
   pry
   pry-rails

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -3,7 +3,9 @@ class LoginController < ApplicationController
 
   def create
     user_data = request.env['omniauth.auth']
-    pertinant_info = UserSerializer.serialize(user_data)
-    require 'pry'; binding.pry
+    user_json = UserSerializer.serialize(user_data)
+    user = UserFacade.new(user_json)
+    session[:user_id] = user.id
+    redirect_to root_path
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -3,7 +3,7 @@ class LoginController < ApplicationController
 
   def create
     user_data = request.env['omniauth.auth']
-    pertinant_info = UserSerializer.new(user_data)
+    pertinant_info = UserSerializer.serialize(user_data)
     require 'pry'; binding.pry
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -4,8 +4,9 @@ class LoginController < ApplicationController
   def create
     user_data = request.env['omniauth.auth']
     user_json = UserSerializer.serialize(user_data)
-    user = UserFacade.new(user_json)
-    session[:user_id] = user.id
+
+    user_id = UserFacade.login(user_json)
+    session[:user_id] = user_id
     redirect_to root_path
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -1,3 +1,9 @@
 class LoginController < ApplicationController
   def index; end
+
+  def create
+    user_data = request.env['omniauth.auth']
+    pertinant_info = UserSerializer.new(user_data)
+    require 'pry'; binding.pry
+  end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,0 +1,5 @@
+class UserFacade
+  def self.login(json)
+    UserService.login(json)[:id]
+  end
+end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,5 +1,5 @@
 class UserFacade
-  def self.login(json)
-    UserService.login(json)[:id]
+  def self.login(user_data)
+    UserService.login(user_data)[:id]
   end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,5 +1,5 @@
 class UserFacade
   def self.login(user_data)
-    UserService.login(user_data)[:id]
+    UserService.login(user_data)[:data][:id]
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,12 @@
+class UserSerializer
+  def self.serialize(data)
+    {
+      uid: data[:uid],
+      full_name: data[:info][:name],
+      email: data[:info][:email],
+      first_name: data[:info][:first_name],
+      last_name: data[:info][:last_name],
+      image: data[:info][:image]
+    }
+  end
+end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -7,9 +7,9 @@ class UserService
     JSON.parse(response.body, symbolize_names: true)
   end
 
-  def self.login(json)
+  def self.login(user_data)
     response = conn.post('/users') do |req|
-      req.body = json
+      req.body = user_data.to_json
     end
 
     parse(response)

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,0 +1,17 @@
+class UserService
+  def self.conn
+    Faraday.new(url: 'http://localhost:5000')
+  end
+
+  def self.parse(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.login(json)
+    response = conn.post('/users') do |req|
+      req.body = json
+    end
+
+    parse(response)
+  end
+end

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -1,3 +1,5 @@
 <%= button_to 'Login', login_path, method: :get %>
 
 <h1>Streamlined</h1>
+
+User ID: <%= session[:user_id] %>

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -1,1 +1,1 @@
-<%= button_to 'Continue With Google', '/', method: :get %>
+<%= button_to 'Continue With Google', google_login_path, method: :get %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,4 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+end
+OmniAuth.config.allowed_request_methods = %i[get]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
 
   get '/login', to: 'login#index'
   get '/auth/google_oauth2', as: :google_login
+  get '/auth/google_oauth2/callback', to: 'login#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root 'landing#index'
 
   get '/login', to: 'login#index'
+  get '/auth/google_oauth2', as: :google_login
 end

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe UserFacade do
+  describe '#login' do
+    it 'can return a collection of cast objects' do
+      stub_request(:post, 'http://localhost:5000/users')
+        .to_return(status: 201,
+                   body: File.read('spec/fixtures/alex_login_response.json'),
+                   headers: {})
+
+      user_data = { uid: '104505147435508023263',
+                    full_name: 'Alex Pitzel',
+                    email: 'pitzelalex@gmail.com',
+                    first_name: 'Alex',
+                    last_name: 'Pitzel',
+                    image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+
+      user = UserFacade.login(user_data)
+
+      expect(user).to be_a String
+      expect(user).to eq('1')
+    end
+  end
+end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -9,21 +9,22 @@ RSpec.describe 'Login Page', type: :feature do
 
       it 'redirect to landing and have session id' do
         stub_request(:post, 'http://localhost:5000/users')
-        .to_return(status: 201,
-                   body: File.read('spec/fixtures/alex_login_response.json'),
-                   headers: {})
+          .to_return(status: 201,
+                     body: File.read('spec/fixtures/alex_login_response.json'),
+                     headers: {})
 
-        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
-                                                                             provider: 'google',
-                                                                             uid: '123545',
-                                                                             info: {
-                                                                               email: 'me@me.com',
-                                                                               name: 'Bono'
-                                                                             },
-                                                                             credentials: {
-                                                                               token: '555'
-                                                                             }
-                                                                           })
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+          { 'provider' => 'google_oauth2',
+            'uid' => '104505147435508023263',
+            'info' =>
+           { 'name' => 'Alex Pitzel',
+             'email' => 'pitzelalex@gmail.com',
+             'unverified_email' => 'pitzelalex@gmail.com',
+             'email_verified' => true,
+             'first_name' => 'Alex',
+             'last_name' => 'Pitzel',
+             'image' => 'https://lh3.googleusercontent.com/a/AGNmyxZxvaMaqWjnwCfSs2_g9yETZREpYAM5GPNneX2pbw=s96-c' } }
+        )
 
         visit login_path
         expect(page).to have_button 'Continue With Google'

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -3,9 +3,35 @@ require 'rails_helper'
 RSpec.describe 'Login Page', type: :feature do
   describe 'when a user' do
     describe 'visits the login path, it' do
-      it 'should display the app name' do
+      before(:each) do
+        OmniAuth.config.test_mode = true
+      end
+
+      it 'redirect to landing and have session id' do
+        stub_request(:post, 'http://localhost:5000/users')
+        .to_return(status: 201,
+                   body: File.read('spec/fixtures/alex_login_response.json'),
+                   headers: {})
+
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+                                                                             provider: 'google',
+                                                                             uid: '123545',
+                                                                             info: {
+                                                                               email: 'me@me.com',
+                                                                               name: 'Bono'
+                                                                             },
+                                                                             credentials: {
+                                                                               token: '555'
+                                                                             }
+                                                                           })
+
         visit login_path
         expect(page).to have_button 'Continue With Google'
+
+        click_button 'Continue With Google'
+
+        expect(current_path).to eq root_path
+        expect(page).to have_content('User ID: 1')
       end
     end
   end

--- a/spec/fixtures/alex_login_response.json
+++ b/spec/fixtures/alex_login_response.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "1",
+    "type": "user",
+    "attributes": {
+      "uid": "104505147435508023263",
+      "full_name": "Alex Pitzel",
+      "email": "pitzelalex@gmail.com",
+      "first_name": "Alex",
+      "last_name": "Pitzel",
+      "image": "https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c"
+    }
+  }
+}

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe UserService do
+  it "can return a user's id" do
+    stub_request(:post, 'http://localhost:5000/users')
+      .to_return(status: 201,
+                 body: File.read('spec/fixtures/alex_login_response.json'),
+                 headers: {})
+
+    user_data = { uid: '104505147435508023263',
+                  full_name: 'Alex Pitzel',
+                  email: 'pitzelalex@gmail.com',
+                  first_name: 'Alex',
+                  last_name: 'Pitzel',
+                  image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+
+    response = UserService.login(user_data)
+
+    expect(response[:data][:id]).to eq('1')
+    expect(response[:data][:type]).to eq('user')
+    expect(response[:data][:attributes][:uid]).to eq('104505147435508023263')
+    expect(response[:data][:attributes][:full_name]).to eq('Alex Pitzel')
+    expect(response[:data][:attributes][:email]).to eq('pitzelalex@gmail.com')
+    expect(response[:data][:attributes][:first_name]).to eq('Alex')
+    expect(response[:data][:attributes][:last_name]).to eq('Pitzel')
+    expect(response[:data][:attributes][:image]).to eq('https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'webmock'
+require 'webmock/rspec'
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Issue #13 

# Summary of things changed:
- Create Serializer for User details from OAuth Ping
- Create login service / facade to ping backend
- Incorporate Omniauth gem to authenticate through Google OAuth2
- Create basic testing for login process
- Implement mocking to mock users post to backend server


# List any known issues (include relevant code snippets): 
  - Sad path not implemented for login
  - OAuth test needs to be reexamined and refactored
  - Service currently can't take in custom headers which will be an issue for future caching
  - Currently using placeholder landing page text to verify session user_id in capybara


# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [ x] All tests are passing 
  - [ x] Code will run locally 
  - [ x] Confirm self-review 
  
# Screenshots of any new or changed FE views:
Nothing to see here

![](https://files.slack.com/files-pri/T029P2S9M-F04QV865HDH/screen_shot_2023-02-22_at_5.38.43_pm.png)
