### PR TITLE
22 onboarding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,8 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
-
 gem 'faraday'
+gem 'omniauth-google-oauth2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,12 +94,14 @@ GEM
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
+    hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    jwt (2.7.0)
     launchy (2.5.2)
       addressable (~> 2.8)
     listen (3.1.5)
@@ -121,6 +123,7 @@ GEM
     mini_portile2 (2.8.1)
     minitest (5.17.0)
     msgpack (1.6.0)
+    multi_xml (0.6.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -136,6 +139,25 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.1.1)
+      jwt (>= 2.0)
+      oauth2 (~> 2.0.6)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8.0)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     orderly (0.1.1)
       capybara (>= 1.1)
       rspec (>= 2.14)
@@ -151,6 +173,8 @@ GEM
     puma (3.12.6)
     racc (1.6.2)
     rack (2.2.6.2)
+    rack-protection (3.0.5)
+      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (5.2.8.1)
@@ -243,6 +267,9 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -259,6 +286,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.4.2)
+    version_gem (1.1.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -290,6 +318,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  omniauth-google-oauth2
   orderly
   pry
   pry-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_user
+
+  def current_user
+    @current_user ||= session[:user_id]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,6 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
 
   def current_user
-    @current_user ||= session[:user_id]
+    @current_user ||= session[:user]
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -4,14 +4,14 @@ class LoginController < ApplicationController
   def create
     user_data = request.env['omniauth.auth']
     user_json = UserSerializer.serialize(user_data)
-    user = UserFacade.login(user_json)
+    @user = UserFacade.login(user_json)
 
-    if user[:user_name] == ''
-      session[:user] = user
-      redirect_to onboarding_path
-    else
-      session[:user] = user
+    if self.onboarded?
+      session[:user] = @user
       redirect_to dashboard_path
+    else
+      session[:user] = @user
+      redirect_to onboarding_path
     end
   end
 
@@ -19,9 +19,15 @@ class LoginController < ApplicationController
   end
 
   def update
-    user = UserFacade.onboard(current_user, params[:user_name])
+    user = UserFacade.onboard(current_user, params[:username])
 
     session[:user] = user
     redirect_to dashboard_path
+  end
+
+  private
+
+  def onboarded?
+    @user[:username] != ''
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -3,7 +3,9 @@ class LoginController < ApplicationController
 
   def create
     user_data = request.env['omniauth.auth']
-    pertinant_info = UserSerializer.serialize(user_data)
-    require 'pry'; binding.pry
+    user_json = UserSerializer.serialize(user_data)
+    user = UserFacade.new(user_json)
+    session[:user_id] = user.id
+    redirect_to root_path
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -3,7 +3,7 @@ class LoginController < ApplicationController
 
   def create
     user_data = request.env['omniauth.auth']
-    pertinant_info = UserSerializer.new(user_data)
+    pertinant_info = UserSerializer.serialize(user_data)
     require 'pry'; binding.pry
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -5,8 +5,8 @@ class LoginController < ApplicationController
     user_data = request.env['omniauth.auth']
     user_json = UserSerializer.serialize(user_data)
 
-    user_id = UserFacade.login(user_json)
-    session[:user_id] = user_id
-    redirect_to root_path
+    user = UserFacade.login(user_json)
+    session[:user] = user
+    redirect_to dashboard_path
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -7,6 +7,7 @@ class LoginController < ApplicationController
     user = UserFacade.login(user_json)
 
     if user[:user_name] == ''
+      session[:user] = user
       redirect_to onboarding_path
     else
       session[:user] = user
@@ -15,6 +16,12 @@ class LoginController < ApplicationController
   end
 
   def edit
+  end
 
+  def update
+    user = UserFacade.onboard(current_user, params[:user_name])
+
+    session[:user] = user
+    redirect_to dashboard_path
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -4,9 +4,17 @@ class LoginController < ApplicationController
   def create
     user_data = request.env['omniauth.auth']
     user_json = UserSerializer.serialize(user_data)
-
     user = UserFacade.login(user_json)
-    session[:user] = user
-    redirect_to dashboard_path
+
+    if user[:user_name] == ''
+      redirect_to onboarding_path
+    else
+      session[:user] = user
+      redirect_to dashboard_path
+    end
+  end
+
+  def edit
+
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -4,8 +4,9 @@ class LoginController < ApplicationController
   def create
     user_data = request.env['omniauth.auth']
     user_json = UserSerializer.serialize(user_data)
-    user = UserFacade.new(user_json)
-    session[:user_id] = user.id
+
+    user_id = UserFacade.login(user_json)
+    session[:user_id] = user_id
     redirect_to root_path
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -1,3 +1,9 @@
 class LoginController < ApplicationController
   def index; end
+
+  def create
+    user_data = request.env['omniauth.auth']
+    pertinant_info = UserSerializer.new(user_data)
+    require 'pry'; binding.pry
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,11 @@
+class UsersController < ApplicationController
+  before_action :fetch_user, only: %i[show]
+
+  def show; end
+
+  private
+
+  def fetch_user
+    @user = session[:user]
+  end
+end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,0 +1,5 @@
+class UserFacade
+  def self.login(json)
+    UserService.login(json)[:id]
+  end
+end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,5 +1,16 @@
 class UserFacade
   def self.login(user_data)
-    UserService.login(user_data)[:data][:id]
+    data = UserService.login(user_data)[:data]
+
+    {
+      id: data[:id],
+      google_id: data[:attributes][:uid],
+      full_name: data[:attributes][:full_name],
+      user_name: data[:attributes][:user_name],
+      email: data[:attributes][:email],
+      first_name: data[:attributes][:first_name],
+      last_name: data[:attributes][:last_name],
+      image: data[:attributes][:image]
+    }
   end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,19 +1,7 @@
 class UserFacade
 
   def self.format(data)
-    # This is for using a struc
-    # User = Struct.new(:id, :uid, :full_name, :username, :email, :first_name, :last_name, :image)
-
-    # user = User.new(
-    #   data[:id],
-    #   data[:attributes][:uid],
-    #   data[:attributes][:full_name],
-    #   data[:attributes][:username],
-    #   data[:attributes][:email],
-    #   data[:attributes][:first_name],
-    #   data[:attributes][:last_name],
-    #   data[:attributes][:image]
-    # )
+    # TODO: Consider a Struct or PORO for User data.
 
     {
       id: data[:id],

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,5 +1,5 @@
 class UserFacade
-  def self.login(json)
-    UserService.login(json)[:id]
+  def self.login(user_data)
+    UserService.login(user_data)[:id]
   end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,5 +1,5 @@
 class UserFacade
   def self.login(user_data)
-    UserService.login(user_data)[:id]
+    UserService.login(user_data)[:data][:id]
   end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,23 +1,25 @@
 class UserFacade
 
   def self.format(data)
-    # User = Struct.new(:id, :google_id, :full_name, :user_name, :email, :first_name, :last_name, :image)
+    # This is for using a struc
+    # User = Struct.new(:id, :uid, :full_name, :username, :email, :first_name, :last_name, :image)
 
     # user = User.new(
     #   data[:id],
     #   data[:attributes][:uid],
     #   data[:attributes][:full_name],
-    #   data[:attributes][:user_name],
+    #   data[:attributes][:username],
     #   data[:attributes][:email],
     #   data[:attributes][:first_name],
     #   data[:attributes][:last_name],
     #   data[:attributes][:image]
     # )
+
     {
       id: data[:id],
-      google_id: data[:attributes][:uid],
+      uid: data[:attributes][:uid],
       full_name: data[:attributes][:full_name],
-      user_name: data[:attributes][:user_name],
+      username: data[:attributes][:username],
       email: data[:attributes][:email],
       first_name: data[:attributes][:first_name],
       last_name: data[:attributes][:last_name],
@@ -29,7 +31,7 @@ class UserFacade
     format(UserService.login(user_data)[:data])
   end
 
-  def self.onboard(current_user, user_name)
-    format(UserService.onboard(current_user, user_name)[:data])
+  def self.onboard(current_user, username)
+    format(UserService.onboard(current_user, username)[:data])
   end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,7 +1,18 @@
 class UserFacade
-  def self.login(user_data)
-    data = UserService.login(user_data)[:data]
 
+  def self.format(data)
+    # User = Struct.new(:id, :google_id, :full_name, :user_name, :email, :first_name, :last_name, :image)
+
+    # user = User.new(
+    #   data[:id],
+    #   data[:attributes][:uid],
+    #   data[:attributes][:full_name],
+    #   data[:attributes][:user_name],
+    #   data[:attributes][:email],
+    #   data[:attributes][:first_name],
+    #   data[:attributes][:last_name],
+    #   data[:attributes][:image]
+    # )
     {
       id: data[:id],
       google_id: data[:attributes][:uid],
@@ -12,5 +23,13 @@ class UserFacade
       last_name: data[:attributes][:last_name],
       image: data[:attributes][:image]
     }
+  end
+
+  def self.login(user_data)
+    format(UserService.login(user_data)[:data])
+  end
+
+  def self.onboard(current_user, user_name)
+    format(UserService.onboard(current_user, user_name)[:data])
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,12 @@
+class UserSerializer
+  def self.serialize(data)
+    {
+      uid: data[:uid],
+      full_name: data[:info][:name],
+      email: data[:info][:email],
+      first_name: data[:info][:first_name],
+      last_name: data[:info][:last_name],
+      image: data[:info][:image]
+    }
+  end
+end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -14,4 +14,13 @@ class UserService
 
     parse(response)
   end
+
+  def self.onboard(current_user, user_name)
+    current_user['user_name'] = user_name
+    response = conn.patch('/users') do |req|
+      req.body = current_user.to_json
+    end
+
+    parse(response)
+  end
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -7,9 +7,9 @@ class UserService
     JSON.parse(response.body, symbolize_names: true)
   end
 
-  def self.login(json)
+  def self.login(user_data)
     response = conn.post('/users') do |req|
-      req.body = json
+      req.body = user_data.to_json
     end
 
     parse(response)

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -15,8 +15,8 @@ class UserService
     parse(response)
   end
 
-  def self.onboard(current_user, user_name)
-    current_user['user_name'] = user_name
+  def self.onboard(current_user, username)
+    current_user['username'] = username
     response = conn.patch('/users') do |req|
       req.body = current_user.to_json
     end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,0 +1,17 @@
+class UserService
+  def self.conn
+    Faraday.new(url: 'http://localhost:5000')
+  end
+
+  def self.parse(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.login(json)
+    response = conn.post('/users') do |req|
+      req.body = json
+    end
+
+    parse(response)
+  end
+end

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -1,3 +1,5 @@
 <%= button_to 'Login', login_path, method: :get %>
 
 <h1>Streamlined</h1>
+
+User ID: <%= session[:user_id] %>

--- a/app/views/login/edit.html.erb
+++ b/app/views/login/edit.html.erb
@@ -1,8 +1,8 @@
 <h2>Welcome to Streamlined</h2>
 
 <%= form_with url: onboarding_path, method: :patch, local: true do |f| %>
-  <%= f.label :user_name, 'Please enter a username' %>
-  <%= f.text_field :user_name %>
+  <%= f.label :username, 'Please enter a username' %>
+  <%= f.text_field :username %>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/login/edit.html.erb
+++ b/app/views/login/edit.html.erb
@@ -1,0 +1,8 @@
+<h2>Welcome to Streamlined</h2>
+
+<%= form_with url: onboarding_path, method: :patch, local: true do |f| %>
+  <%= f.label :user_name, 'Please enter a username' %>
+  <%= f.text_field :user_name %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -1,1 +1,1 @@
-<%= button_to 'Continue With Google', '/', method: :get %>
+<%= button_to 'Continue With Google', google_login_path, method: :get %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,1 @@
+<%= @user['user_name'] %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,1 @@
-<%= @user['user_name'] %>
+<%= @user['username'] %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,4 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+end
+OmniAuth.config.allowed_request_methods = %i[get]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   get '/auth/google_oauth2/callback', to: 'login#create'
   get '/dashboard', to: 'users#show'
   get '/onboarding', to: 'login#edit'
+  patch '/onboarding', to: 'login#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
 
   get '/login', to: 'login#index'
   get '/auth/google_oauth2', as: :google_login
+  get '/auth/google_oauth2/callback', to: 'login#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root 'landing#index'
 
   get '/login', to: 'login#index'
+  get '/auth/google_oauth2', as: :google_login
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get '/auth/google_oauth2', as: :google_login
   get '/auth/google_oauth2/callback', to: 'login#create'
   get '/dashboard', to: 'users#show'
+  get '/onboarding', to: 'login#edit'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   get '/login', to: 'login#index'
   get '/auth/google_oauth2', as: :google_login
   get '/auth/google_oauth2/callback', to: 'login#create'
+  get '/dashboard', to: 'users#show'
 end

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UserFacade do
   describe '#login' do
-    it 'can return a collection of cast objects' do
+    it 'can return a hash of user details' do
       stub_request(:post, 'http://localhost:5000/users')
         .to_return(status: 201,
                    body: File.read('spec/fixtures/alex_login_response.json'),
@@ -17,8 +17,15 @@ RSpec.describe UserFacade do
 
       user = UserFacade.login(user_data)
 
-      expect(user).to be_a String
-      expect(user).to eq('1')
+      expect(user).to be_a Hash
+      expect(user[:id]).to eq('1')
+      expect(user[:google_id]).to eq('104505147435508023263')
+      expect(user[:full_name]).to eq('Alex Pitzel')
+      expect(user[:user_name]).to eq('pitzelalex')
+      expect(user[:email]).to eq('pitzelalex@gmail.com')
+      expect(user[:first_name]).to eq('Alex')
+      expect(user[:last_name]).to eq('Pitzel')
+      expect(user[:image]).to eq('https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c')
     end
   end
 end

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe UserFacade do
+  describe '#login' do
+    it 'can return a collection of cast objects' do
+      stub_request(:post, 'http://localhost:5000/users')
+        .to_return(status: 201,
+                   body: File.read('spec/fixtures/alex_login_response.json'),
+                   headers: {})
+
+      user_data = { uid: '104505147435508023263',
+                    full_name: 'Alex Pitzel',
+                    email: 'pitzelalex@gmail.com',
+                    first_name: 'Alex',
+                    last_name: 'Pitzel',
+                    image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+
+      user = UserFacade.login(user_data)
+
+      expect(user).to be_a String
+      expect(user).to eq('1')
+    end
+  end
+end

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -19,9 +19,39 @@ RSpec.describe UserFacade do
 
       expect(user).to be_a Hash
       expect(user[:id]).to eq('1')
-      expect(user[:google_id]).to eq('104505147435508023263')
+      expect(user[:uid]).to eq('104505147435508023263')
       expect(user[:full_name]).to eq('Alex Pitzel')
-      expect(user[:user_name]).to eq('pitzelalex')
+      expect(user[:username]).to eq('pitzelalex')
+      expect(user[:email]).to eq('pitzelalex@gmail.com')
+      expect(user[:first_name]).to eq('Alex')
+      expect(user[:last_name]).to eq('Pitzel')
+      expect(user[:image]).to eq('https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c')
+    end
+  end
+
+  describe '#onboard' do
+    it 'can return a hash of user details' do
+      stub_request(:patch, 'http://localhost:5000/users')
+        .to_return(status: 201,
+                   body: File.read('spec/fixtures/alex_login_response.json'),
+                   headers: {})
+
+      current_user = { 'id' => '1',
+                       'uid' => '104505147435508023263',
+                       'full_name' => 'Alex Pitzel',
+                       'username' => '',
+                       'email' => 'pitzelalex@gmail.com',
+                       'first_name' => 'Alex',
+                       'last_name' => 'Pitzel',
+                       'image' => 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+
+      user = UserFacade.onboard(current_user, 'pitzelalex')
+
+      expect(user).to be_a Hash
+      expect(user[:id]).to eq('1')
+      expect(user[:uid]).to eq('104505147435508023263')
+      expect(user[:full_name]).to eq('Alex Pitzel')
+      expect(user[:username]).to eq('pitzelalex')
       expect(user[:email]).to eq('pitzelalex@gmail.com')
       expect(user[:first_name]).to eq('Alex')
       expect(user[:last_name]).to eq('Pitzel')

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe UserFacade do
                    headers: {})
 
       current_user = { 'id' => '1',
-                       'google_id' => '104505147435508023263',
+                       'uid' => '104505147435508023263',
                        'full_name' => 'Alex Pitzel',
-                       'user_name' => '',
+                       'username' => '',
                        'email' => 'pitzelalex@gmail.com',
                        'first_name' => 'Alex',
                        'last_name' => 'Pitzel',
@@ -79,9 +79,9 @@ RSpec.describe UserFacade do
 
       expect(user).to be_a Hash
       expect(user[:id]).to eq('1')
-      expect(user[:google_id]).to eq('104505147435508023263')
+      expect(user[:uid]).to eq('104505147435508023263')
       expect(user[:full_name]).to eq('Alex Pitzel')
-      expect(user[:user_name]).to eq('pitzelalex')
+      expect(user[:username]).to eq('pitzelalex')
       expect(user[:email]).to eq('pitzelalex@gmail.com')
       expect(user[:first_name]).to eq('Alex')
       expect(user[:last_name]).to eq('Pitzel')

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -2,37 +2,57 @@ require 'rails_helper'
 
 RSpec.describe 'Login Page', type: :feature do
   describe 'when a user' do
-    describe 'visits the login path, it' do
+    describe 'visits the login path' do
       before(:each) do
         OmniAuth.config.test_mode = true
-      end
-
-      it 'redirect to landing and have session id' do
-        stub_request(:post, 'http://localhost:5000/users')
-          .to_return(status: 201,
-                     body: File.read('spec/fixtures/alex_login_response.json'),
-                     headers: {})
 
         OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
           { 'provider' => 'google_oauth2',
             'uid' => '104505147435508023263',
             'info' =>
-           { 'name' => 'Alex Pitzel',
-             'email' => 'pitzelalex@gmail.com',
-             'unverified_email' => 'pitzelalex@gmail.com',
-             'email_verified' => true,
-             'first_name' => 'Alex',
-             'last_name' => 'Pitzel',
-             'image' => 'https://lh3.googleusercontent.com/a/AGNmyxZxvaMaqWjnwCfSs2_g9yETZREpYAM5GPNneX2pbw=s96-c' } }
+          { 'name' => 'Alex Pitzel',
+            'email' => 'pitzelalex@gmail.com',
+            'unverified_email' => 'pitzelalex@gmail.com',
+            'email_verified' => true,
+            'first_name' => 'Alex',
+            'last_name' => 'Pitzel',
+            'image' => 'https://lh3.googleusercontent.com/a/AGNmyxZxvaMaqWjnwCfSs2_g9yETZREpYAM5GPNneX2pbw=s96-c' } }
         )
+      end
 
-        visit login_path
-        expect(page).to have_button 'Continue With Google'
+      describe 'and they have previously logged in' do
+        before(:each) do
+          stub_request(:post, 'http://localhost:5000/users')
+            .to_return(status: 201,
+                       body: File.read('spec/fixtures/alex_login_response.json'),
+                       headers: {})
+        end
 
-        click_button 'Continue With Google'
+        it "they're redirected to their dashboard" do
+          visit login_path
+          expect(page).to have_button 'Continue With Google'
 
-        expect(current_path).to eq dashboard_path
-        expect(page).to have_content('pitzelalex')
+          click_button 'Continue With Google'
+
+          expect(current_path).to eq dashboard_path
+          expect(page).to have_content('pitzelalex')
+        end
+      end
+
+      describe "and it's their first time logging in" do
+        before(:each) do
+          stub_request(:post, 'http://localhost:5000/users')
+            .to_return(status: 201,
+                       body: File.read('spec/fixtures/alex_first_login_response.json'),
+                       headers: {})
+        end
+
+        it "they're redirected to the onboarding page" do
+          visit login_path
+          click_button 'Continue With Google'
+
+          expect(current_path).to eq onboarding_path
+        end
       end
     end
   end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -9,21 +9,22 @@ RSpec.describe 'Login Page', type: :feature do
 
       it 'redirect to landing and have session id' do
         stub_request(:post, 'http://localhost:5000/users')
-        .to_return(status: 201,
-                   body: File.read('spec/fixtures/alex_login_response.json'),
-                   headers: {})
+          .to_return(status: 201,
+                     body: File.read('spec/fixtures/alex_login_response.json'),
+                     headers: {})
 
-        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
-                                                                             provider: 'google',
-                                                                             uid: '123545',
-                                                                             info: {
-                                                                               email: 'me@me.com',
-                                                                               name: 'Bono'
-                                                                             },
-                                                                             credentials: {
-                                                                               token: '555'
-                                                                             }
-                                                                           })
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+          { 'provider' => 'google_oauth2',
+            'uid' => '104505147435508023263',
+            'info' =>
+           { 'name' => 'Alex Pitzel',
+             'email' => 'pitzelalex@gmail.com',
+             'unverified_email' => 'pitzelalex@gmail.com',
+             'email_verified' => true,
+             'first_name' => 'Alex',
+             'last_name' => 'Pitzel',
+             'image' => 'https://lh3.googleusercontent.com/a/AGNmyxZxvaMaqWjnwCfSs2_g9yETZREpYAM5GPNneX2pbw=s96-c' } }
+        )
 
         visit login_path
         expect(page).to have_button 'Continue With Google'

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'Login Page', type: :feature do
 
         click_button 'Continue With Google'
 
-        expect(current_path).to eq root_path
-        expect(page).to have_content('User ID: 1')
+        expect(current_path).to eq dashboard_path
+        expect(page).to have_content('pitzelalex')
       end
     end
   end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -3,9 +3,35 @@ require 'rails_helper'
 RSpec.describe 'Login Page', type: :feature do
   describe 'when a user' do
     describe 'visits the login path, it' do
-      it 'should display the app name' do
+      before(:each) do
+        OmniAuth.config.test_mode = true
+      end
+
+      it 'redirect to landing and have session id' do
+        stub_request(:post, 'http://localhost:5000/users')
+        .to_return(status: 201,
+                   body: File.read('spec/fixtures/alex_login_response.json'),
+                   headers: {})
+
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+                                                                             provider: 'google',
+                                                                             uid: '123545',
+                                                                             info: {
+                                                                               email: 'me@me.com',
+                                                                               name: 'Bono'
+                                                                             },
+                                                                             credentials: {
+                                                                               token: '555'
+                                                                             }
+                                                                           })
+
         visit login_path
         expect(page).to have_button 'Continue With Google'
+
+        click_button 'Continue With Google'
+
+        expect(current_path).to eq root_path
+        expect(page).to have_content('User ID: 1')
       end
     end
   end

--- a/spec/features/onboarding_spec.rb
+++ b/spec/features/onboarding_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe 'Onboarding Page', type: :feature do
             .to_return(status: 201,
                        body: File.read('spec/fixtures/alex_first_login_response.json'),
                        headers: {})
+
+    stub_request(:patch, 'http://localhost:5000/users')
+            .to_return(status: 201,
+                       body: File.read('spec/fixtures/alex_login_response.json'),
+                       headers: {})
   end
 
   describe 'when a user has logged in for the first time' do
@@ -30,9 +35,9 @@ RSpec.describe 'Onboarding Page', type: :feature do
 
       expect(page).to have_content('Welcome to Streamlined')
       expect(page).to have_content('Please enter a username')
-      expect(page).to have_field 'user_name'
+      expect(page).to have_field 'username'
 
-      fill_in 'user_name', with: 'pitzelalex'
+      fill_in 'username', with: 'pitzelalex'
 
       click_button 'Save'
 

--- a/spec/features/onboarding_spec.rb
+++ b/spec/features/onboarding_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'Onboarding Page', type: :feature do
+  before(:each) do
+    OmniAuth.config.test_mode = true
+
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      { 'provider' => 'google_oauth2',
+        'uid' => '104505147435508023263',
+        'info' =>
+      { 'name' => 'Alex Pitzel',
+        'email' => 'pitzelalex@gmail.com',
+        'unverified_email' => 'pitzelalex@gmail.com',
+        'email_verified' => true,
+        'first_name' => 'Alex',
+        'last_name' => 'Pitzel',
+        'image' => 'https://lh3.googleusercontent.com/a/AGNmyxZxvaMaqWjnwCfSs2_g9yETZREpYAM5GPNneX2pbw=s96-c' } }
+    )
+
+    stub_request(:post, 'http://localhost:5000/users')
+            .to_return(status: 201,
+                       body: File.read('spec/fixtures/alex_first_login_response.json'),
+                       headers: {})
+  end
+
+  describe 'when a user has logged in for the first time' do
+    it 'they see a prompt to provide a user name' do
+      visit login_path
+      click_button 'Continue With Google'
+
+      expect(page).to have_content('Welcome to Streamlined')
+      expect(page).to have_content('Please enter a username')
+      expect(page).to have_field 'user_name'
+
+      fill_in 'user_name', with: 'pitzelalex'
+
+      click_button 'Save'
+
+      expect(current_path).to eq dashboard_path
+      expect(page).to have_content('pitzelalex')
+    end
+  end
+end

--- a/spec/fixtures/alex_first_login_response.json
+++ b/spec/fixtures/alex_first_login_response.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": "1",
+    "type": "user",
+    "attributes": {
+      "uid": "104505147435508023263",
+      "full_name": "Alex Pitzel",
+      "user_name": "",
+      "email": "pitzelalex@gmail.com",
+      "first_name": "Alex",
+      "last_name": "Pitzel",
+      "image": "https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c"
+    }
+  }
+}

--- a/spec/fixtures/alex_first_login_response.json
+++ b/spec/fixtures/alex_first_login_response.json
@@ -5,7 +5,7 @@
     "attributes": {
       "uid": "104505147435508023263",
       "full_name": "Alex Pitzel",
-      "user_name": "",
+      "username": "",
       "email": "pitzelalex@gmail.com",
       "first_name": "Alex",
       "last_name": "Pitzel",

--- a/spec/fixtures/alex_login_response.json
+++ b/spec/fixtures/alex_login_response.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "1",
+    "type": "user",
+    "attributes": {
+      "uid": "104505147435508023263",
+      "full_name": "Alex Pitzel",
+      "email": "pitzelalex@gmail.com",
+      "first_name": "Alex",
+      "last_name": "Pitzel",
+      "image": "https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c"
+    }
+  }
+}

--- a/spec/fixtures/alex_login_response.json
+++ b/spec/fixtures/alex_login_response.json
@@ -5,6 +5,7 @@
     "attributes": {
       "uid": "104505147435508023263",
       "full_name": "Alex Pitzel",
+      "user_name": "pitzelalex",
       "email": "pitzelalex@gmail.com",
       "first_name": "Alex",
       "last_name": "Pitzel",

--- a/spec/fixtures/alex_login_response.json
+++ b/spec/fixtures/alex_login_response.json
@@ -5,7 +5,7 @@
     "attributes": {
       "uid": "104505147435508023263",
       "full_name": "Alex Pitzel",
-      "user_name": "pitzelalex",
+      "username": "pitzelalex",
       "email": "pitzelalex@gmail.com",
       "first_name": "Alex",
       "last_name": "Pitzel",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,3 +71,5 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+OmniAuth.config.silence_get_warning = true

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe UserService do
     expect(response[:data][:type]).to eq('user')
     expect(response[:data][:attributes][:uid]).to eq('104505147435508023263')
     expect(response[:data][:attributes][:full_name]).to eq('Alex Pitzel')
+    expect(response[:data][:attributes][:user_name]).to eq('pitzelalex')
     expect(response[:data][:attributes][:email]).to eq('pitzelalex@gmail.com')
     expect(response[:data][:attributes][:first_name]).to eq('Alex')
     expect(response[:data][:attributes][:last_name]).to eq('Pitzel')

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -1,31 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe UserService do
-  let(:user_data) do
-    { uid: '104505147435508023263',
-      full_name: 'Alex Pitzel',
-      email: 'pitzelalex@gmail.com',
-      first_name: 'Alex',
-      last_name: 'Pitzel',
-      image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+  describe '#login' do
+    let(:user_data) do
+      { uid: '104505147435508023263',
+        full_name: 'Alex Pitzel',
+        email: 'pitzelalex@gmail.com',
+        first_name: 'Alex',
+        last_name: 'Pitzel',
+        image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+    end
+
+    it 'can get details about a user from the back end' do
+      stub_request(:post, 'http://localhost:5000/users')
+        .to_return(status: 201,
+                   body: File.read('spec/fixtures/alex_login_response.json'),
+                   headers: {})
+
+      response = UserService.login(user_data)
+
+      expect(response[:data][:id]).to eq('1')
+      expect(response[:data][:type]).to eq('user')
+      expect(response[:data][:attributes][:uid]).to eq('104505147435508023263')
+      expect(response[:data][:attributes][:full_name]).to eq('Alex Pitzel')
+      expect(response[:data][:attributes][:username]).to eq('pitzelalex')
+      expect(response[:data][:attributes][:email]).to eq('pitzelalex@gmail.com')
+      expect(response[:data][:attributes][:first_name]).to eq('Alex')
+      expect(response[:data][:attributes][:last_name]).to eq('Pitzel')
+      expect(response[:data][:attributes][:image]).to eq('https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c')
+    end
   end
 
-  it 'can get details about a user from the back end' do
-    stub_request(:post, 'http://localhost:5000/users')
-      .to_return(status: 201,
-                 body: File.read('spec/fixtures/alex_login_response.json'),
-                 headers: {})
+  describe '#onboard' do
+    let(:user_data) do
+      { 'id' => '1',
+        'uid' => '104505147435508023263',
+        'full_name' => 'Alex Pitzel',
+        'username' => '',
+        'email' => 'pitzelalex@gmail.com',
+        'first_name' => 'Alex',
+        'last_name' => 'Pitzel',
+        'image' => 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+    end
 
-    response = UserService.login(user_data)
+    it 'updates the user entry and gets the details' do
+      stub_request(:patch, 'http://localhost:5000/users')
+        .to_return(status: 201,
+                   body: File.read('spec/fixtures/alex_login_response.json'),
+                   headers: {})
 
-    expect(response[:data][:id]).to eq('1')
-    expect(response[:data][:type]).to eq('user')
-    expect(response[:data][:attributes][:uid]).to eq('104505147435508023263')
-    expect(response[:data][:attributes][:full_name]).to eq('Alex Pitzel')
-    expect(response[:data][:attributes][:user_name]).to eq('pitzelalex')
-    expect(response[:data][:attributes][:email]).to eq('pitzelalex@gmail.com')
-    expect(response[:data][:attributes][:first_name]).to eq('Alex')
-    expect(response[:data][:attributes][:last_name]).to eq('Pitzel')
-    expect(response[:data][:attributes][:image]).to eq('https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c')
+      response = UserService.onboard(user_data, 'pitzelalex')
+
+      expect(response[:data][:id]).to eq('1')
+      expect(response[:data][:type]).to eq('user')
+      expect(response[:data][:attributes][:uid]).to eq('104505147435508023263')
+      expect(response[:data][:attributes][:full_name]).to eq('Alex Pitzel')
+      expect(response[:data][:attributes][:username]).to eq('pitzelalex')
+      expect(response[:data][:attributes][:email]).to eq('pitzelalex@gmail.com')
+      expect(response[:data][:attributes][:first_name]).to eq('Alex')
+      expect(response[:data][:attributes][:last_name]).to eq('Pitzel')
+      expect(response[:data][:attributes][:image]).to eq('https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c')
+    end
   end
 end

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -1,18 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe UserService do
-  it "can return a user's id" do
+  let(:user_data) do
+    { uid: '104505147435508023263',
+      full_name: 'Alex Pitzel',
+      email: 'pitzelalex@gmail.com',
+      first_name: 'Alex',
+      last_name: 'Pitzel',
+      image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+  end
+
+  it 'can get details about a user from the back end' do
     stub_request(:post, 'http://localhost:5000/users')
       .to_return(status: 201,
                  body: File.read('spec/fixtures/alex_login_response.json'),
                  headers: {})
-
-    user_data = { uid: '104505147435508023263',
-                  full_name: 'Alex Pitzel',
-                  email: 'pitzelalex@gmail.com',
-                  first_name: 'Alex',
-                  last_name: 'Pitzel',
-                  image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
 
     response = UserService.login(user_data)
 

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe UserService do
+  it "can return a user's id" do
+    stub_request(:post, 'http://localhost:5000/users')
+      .to_return(status: 201,
+                 body: File.read('spec/fixtures/alex_login_response.json'),
+                 headers: {})
+
+    user_data = { uid: '104505147435508023263',
+                  full_name: 'Alex Pitzel',
+                  email: 'pitzelalex@gmail.com',
+                  first_name: 'Alex',
+                  last_name: 'Pitzel',
+                  image: 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
+
+    response = UserService.login(user_data)
+
+    expect(response[:data][:id]).to eq('1')
+    expect(response[:data][:type]).to eq('user')
+    expect(response[:data][:attributes][:uid]).to eq('104505147435508023263')
+    expect(response[:data][:attributes][:full_name]).to eq('Alex Pitzel')
+    expect(response[:data][:attributes][:email]).to eq('pitzelalex@gmail.com')
+    expect(response[:data][:attributes][:first_name]).to eq('Alex')
+    expect(response[:data][:attributes][:last_name]).to eq('Pitzel')
+    expect(response[:data][:attributes][:image]).to eq('https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'webmock'
+require 'webmock/rspec'
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Closes Issue #22 

# Summary of things changed:
  - Changes session cookie to now store the entire set of details about a user upon successful login
  - Adds a condition that redirects user to onboarding page is user_name field is not populated
  - Adds the onboarding view and form that sends a patch request to the back end after user completes onboarding

# List any known issues (include relevant code snippets): 
  - User Facade needs a refactor to better use the #format method (Possibly a serializer?)
  - Might need a refactor pass to change user_name to username if that is a more standard syntax we want
  - Relies on user_name field being an empty string `''` instead of nill. This could potentially not be robust enough

# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [ x] All tests are passing 
  - [ x] Code will run locally 
  - [ x] Confirm self-review 
  
# Screenshots of any new or changed FE views:
![image](https://user-images.githubusercontent.com/112970613/221044080-fe3a7c0f-f19e-4449-976c-69de3cf54c93.png)