### PR TITLE
6 dashboard edit

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -19,7 +19,7 @@ class LoginController < ApplicationController
   end
 
   def update
-    user = UserFacade.onboard(current_user, params[:username])
+    user = UserFacade.edit_user(current_user, params[:username])
 
     session[:user] = user
     redirect_to dashboard_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,12 @@ class UsersController < ApplicationController
 
   def edit; end
 
+  def update
+    user = UserFacade.edit_profile(current_user, params[:username])
+
+    redirect_to dashboard_path
+  end
+
   private
 
   def fetch_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,19 +1,11 @@
 class UsersController < ApplicationController
-  before_action :fetch_user, only: %i[show]
-
   def show; end
 
   def edit; end
 
   def update
-    user = UserFacade.edit_profile(current_user, params[:username])
-
+    user = UserFacade.edit_user(current_user, params[:username])
+    session[:user] = user
     redirect_to dashboard_path
-  end
-
-  private
-
-  def fetch_user
-    @user = session[:user]
   end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -15,7 +15,11 @@ class UserFacade
     format(UserService.login(user_data)[:data])
   end
 
-  def self.onboard(current_user, username)
-    format(UserService.onboard(current_user, username)[:data])
+  # def self.onboard(current_user, username)
+  #   format(UserService.onboard(current_user, username)[:data])
+  # end
+
+  def self.edit_user(current_user, username)
+    format(UserService.edit_user(current_user, username)[:data])
   end
 end

--- a/app/poros/user.rb
+++ b/app/poros/user.rb
@@ -1,0 +1,17 @@
+class User
+  attr_reader :id,
+              :sub,
+              :name,
+              :username,
+              :email,
+              :picture
+
+  def initialize(user_data)
+    @id = user_data[:id]
+    @sub = user_data[:sub]
+    @name = user_data[:name]
+    @username = user_data[:username]
+    @email = user_data[:email]
+    @picture = user_data[:picture]
+  end
+end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -15,20 +15,17 @@ class UserService
     parse(response)
   end
 
-  def self.onboard(current_user, username)
-    current_user['username'] = username
+  def self.edit_user(current_user, username)
     response = conn.patch("/api/v1/users/#{current_user['id']}") do |req|
-      req.body = current_user
+      req.body = { username: username }
     end
 
     parse(response)
   end
 
-  private
-
   def self.service_params
     {
-      url: 'http://localhost:5000'
+      url: ENV['user_base_url']
     }
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,6 @@
+<%= form_with url: dashboard_edit_path, method: :patch, local: true do |f| %>
+  <%= f.label :username, 'Please enter new Username:' %>
+  <%= f.text_field :username, value: current_user['username'] %>
+
+  <%= f.submit 'Update Username' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   get '/search', to: 'search#index'
   get '/dashboard', to: 'users#show'
   get '/dashboard/edit', to: 'users#edit'
+  patch '/dashboard/edit', to: 'users#update'
   get '/onboarding', to: 'login#edit'
   patch '/onboarding', to: 'login#update'
 end
-

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UserFacade do
     end
   end
 
-  describe '#onboard' do
+  describe '#edit_user' do
     it 'can return a hash of user details' do
       stub_request(:patch, 'http://localhost:5000/api/v1/users/1')
         .to_return(status: 201,
@@ -39,7 +39,7 @@ RSpec.describe UserFacade do
                        'email' => 'pitzelalex@gmail.com',
                        'picture' => 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
 
-      user = UserFacade.onboard(current_user, 'pitzelalex')
+      user = UserFacade.edit_user(current_user, 'pitzelalex')
 
       expect(user).to be_a Hash
       expect(user[:id]).to eq('1')
@@ -51,7 +51,7 @@ RSpec.describe UserFacade do
     end
   end
 
-  describe '#onboard' do
+  describe '#edit_user' do
     it 'can return a hash of user details' do
       stub_request(:patch, 'http://localhost:5000/api/v1/users/1')
         .to_return(status: 201,
@@ -65,7 +65,7 @@ RSpec.describe UserFacade do
                        'email' => 'pitzelalex@gmail.com',
                        'picture' => 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c' }
 
-      user = UserFacade.onboard(current_user, 'pitzelalex')
+      user = UserFacade.edit_user(current_user, 'pitzelalex')
 
       expect(user).to be_a Hash
       expect(user[:id]).to eq('1')

--- a/spec/features/dashboard/edit_spec.rb
+++ b/spec/features/dashboard/edit_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'user dashboard edit', type: :feature do
+  describe 'as a logged in user' do
+    let(:user) do
+      {
+        'id' => '1',
+        'sub' => '104505147435508023263',
+        'name' => 'Alex Pitzel',
+        'username' => 'pitzelalex',
+        'email' => 'pitzelalex@gmail.com',
+        'picture' => 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c'
+      }
+    end
+
+    it 'has a field to edit username', :vcr do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_edit_path
+
+      expect(page).to have_field('username', with: 'pitzelalex')
+      expect(page).to have_button 'Update Username'
+
+      fill_in 'username', with: 'new_username'
+
+      click_button 'Update Username'
+
+      expect(current_path).to eq dashboard_path
+
+      expect(page).to have_content('Username: new_username')
+    end
+
+    it 'has a button to delete account'
+  end
+end

--- a/spec/features/dashboard/edit_spec.rb
+++ b/spec/features/dashboard/edit_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe 'user dashboard edit', type: :feature do
       }
     end
 
+    let(:new_user) do
+      {
+        'id' => '1',
+        'sub' => '104505147435508023263',
+        'name' => 'Alex Pitzel',
+        'username' => 'new_username',
+        'email' => 'pitzelalex@gmail.com',
+        'picture' => 'https://lh3.googleusercontent.com/a/AEdFTp5vj_rzxJzWHjgqM1-InqDI0fJWxwpHK_zElpKLgA=s96-c'
+      }
+    end
+
     it 'has a field to edit username', :vcr do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -22,6 +33,8 @@ RSpec.describe 'user dashboard edit', type: :feature do
       expect(page).to have_button 'Update Username'
 
       fill_in 'username', with: 'new_username'
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(new_user)
 
       click_button 'Update Username'
 

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'user show page', type: :feature do
+RSpec.describe 'user dashboard', type: :feature do
   describe 'as a logged in user' do
     let(:user) do
       {

--- a/spec/features/onboarding_spec.rb
+++ b/spec/features/onboarding_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Onboarding Page', type: :feature do
   describe 'when a user has logged in for the first time' do
     before(:each) do
-      user = { 'id' => '1', 'name' => 'test' }
+      user = { 'id' => '1', 'name' => 'test', 'username' => 'pitzelalex' }
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       stub_request(:patch, 'http://localhost:5000/api/v1/users/1')

--- a/spec/fixtures/vcr_cassettes/user_dashboard_edit/as_a_logged_in_user/has_a_field_to_edit_username.yml
+++ b/spec/fixtures/vcr_cassettes/user_dashboard_edit/as_a_logged_in_user/has_a_field_to_edit_username.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: http://localhost:5000/api/v1/users/1
+    body:
+      encoding: UTF-8
+      string: username=new_username
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"7414934dda746c250495f7c2e95f1d49"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b8a42b00-c631-4254-bb54-42e30a8dbe87
+      X-Runtime:
+      - '0.085266'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"1","type":"user","attributes":{"sub":"104505147435508023263","username":"new_username","email":"pitzelalex@gmail.com","name":"Alex
+        Pitzel","picture":"https://lh3.googleusercontent.com/a/AGNmyxZxvaMaqWjnwCfSs2_g9yETZREpYAM5GPNneX2pbw=s96-c"}}}'
+  recorded_at: Sun, 26 Feb 2023 19:45:37 GMT
+recorded_with: VCR 6.1.0

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe UserService do
     end
   end
 
-  describe '#onboard' do
+  describe '#edit_user' do
     let(:user_data) do
       { 'id' => '1',
         'sub' => '104505147435508023263',
@@ -43,7 +43,7 @@ RSpec.describe UserService do
                    body: File.read('spec/fixtures/alex_login_response.json'),
                    headers: {})
 
-      response = UserService.onboard(user_data, 'pitzelalex')
+      response = UserService.edit_user(user_data, 'pitzelalex')
 
       expect(response[:data][:id]).to eq('1')
       expect(response[:data][:type]).to eq('user')


### PR DESCRIPTION
Closes Issue #6 

# Summary of things changed:
 - Refactor user service / facade to use one edit_user action instead of identical onboarding and update_username actions
 - Adds edit form to edit page
 - updates tests to work with new facade / service methods
 - creates an untested User Poro that will be utilized in the refactor


# List any known issues (include relevant code snippets): 
  - Tests are kind of useless as it stands. This needs a fundamental change in how we handle current user. This is addressed by Issue #34 
  - The User Poro is not being utilized. This will also be addressed in #34 
  - One unimplemented test for the delete account button that has been pushed to a later issue


# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [ ] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Screenshots of any new or changed FE views:

![Screen Shot 2023-02-26 at 3 29 40 PM](https://user-images.githubusercontent.com/112970613/221435454-3e3c1bff-c6f9-4a8f-8b4f-1c867406f4db.png)
