### PR TITLE
Media details formatting

### DIFF
--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -12,7 +12,8 @@ class Media
               :language,
               :audience_score,
               :trailer, 
-              :vote_average
+              :vote_average,
+              :genre
 
 
   def initialize(data)
@@ -48,5 +49,9 @@ class Media
 
   def round_vote 
     @vote_average.round(1)
+  end
+
+  def trailer_id
+    trailer.partition('=').last
   end
 end

--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -2,11 +2,11 @@
 
 <div class="row">
   <% if @media.poster %>
-    <div class='poster col-md-4'>
+    <div class='poster col-md-3'>
       <%= image_tag(@media.poster, height:'100%', width:'100%') %>
     </div>
   <% end %>
-  <div class='col-md-8'>
+  <div class='col-md-9'>
     <h4>Synopsis: </h4><%= @media.description %>
     <br>
     Audience Rating: <%= @media.audience_score %>

--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -1,15 +1,41 @@
-<%= @media.title %>
-<div class='poster'>
-  <%= image_tag @media.poster %>
+<h2><center><%= @media.title %></center></h2>
+
+<div class="row">
+  <% if @media.poster %>
+    <div class='poster col-md-4'>
+      <%= image_tag(@media.poster, height:'100%', width:'100%') %>
+    </div>
+  <% end %>
+  <div class='col-md-8'>
+    <h4>Synopsis: </h4><%= @media.description %>
+    <br>
+    Audience Rating: <%= @media.audience_score %>
+    <br>
+    <% if @media.genre != [] %>
+      Genres: <%= @media.genres %>
+      <br>
+    <% end %>
+    Runtime: <%= @media.runtime %> minutes
+    <br>
+    Release year: <%= @media.release_year %>
+    <br>
+    <% if @media.rating %>
+      Rating: <%= @media.rating %>
+      <br>
+      <% end %>
+    <br>
+    <% if @media.sub_services.present? %>
+      Available for Streaming on: <%= @media.sub_services %>
+    <% else %>
+      Not currently available on any subscription streaming services
+    <% end %>
+    <br>
+    Media Type: <%= @media.formatted_type %>
+    <br>
+    <% if @media.trailer %>
+      <h5>Trailer</h5>
+      <iframe width="600" height="336" src='https://www.youtube.com/embed/<%= @media.trailer_id %>?rel=0&autoplay=<%= params[:autoplay] || 0 %>' frameborder='0' allowfullscreen>
+      </iframe>
+    <% end %>
+  </div>
 </div>
-<%= @media.description %>
-<%= @media.audience_score %>
-<%= @media.genres %>
-<%= @media.runtime %>
-<%= @media.type %>
-<%= @media.release_year %>
-<%= @media.rating %>
-<%= @media.trailer %>
-<%= @media.language %>
-<%= @media.sub_services %>
-<%= link_to 'Link to Trailer', @media.trailer %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,7 +3,7 @@
 <% @media_results.each do |media| %>
   <div id="media_<%= media.id %>">
     <h3><%= link_to media.title, media_path(media.id) %></h3>
-    <p><img src=<%= media.poster %>></p>
+    <p><%= link_to image_tag(media.poster), media_path(media.id)  %></p>
     <p>Media Type: <%= media.formatted_type %></p>
     <p>Release Year: <%= media.release_year %></p>
   </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,7 +3,9 @@
 <% @media_results.each do |media| %>
   <div id="media_<%= media.id %>">
     <h3><%= link_to media.title, media_path(media.id) %></h3>
-    <p><%= link_to image_tag(media.poster), media_path(media.id)  %></p>
+    <% if media.poster %>
+      <p><%= link_to image_tag(media.poster), media_path(media.id)  %></p>
+    <% end %>
     <p>Media Type: <%= media.formatted_type %></p>
     <p>Release Year: <%= media.release_year %></p>
   </div>

--- a/spec/features/media/show_spec.rb
+++ b/spec/features/media/show_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'The Media Show page', type: :feature do
       end
 
       it 'shows media type' do
-        expect(page).to have_content 'tv_series'
+        expect(page).to have_content 'Tv'
       end
 
       it 'shows media release year' do
@@ -50,8 +50,8 @@ RSpec.describe 'The Media Show page', type: :feature do
         expect(page).to have_content 'Netflix'
       end
 
-      it 'shows media trailer link' do
-        expect(page).to have_link 'Link to Trailer'
+      it 'shows media trailer video' do
+        expect(page).to have_css 'iframe'
       end
     end
   end

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -37,4 +37,10 @@ RSpec.describe Media do
   it 'can reformat the sub_services' do 
     expect(@media.sub_services).to eq('Netflix')
   end
+
+  describe '#trailer_id' do
+    it 'takes the youtube link and returns just the youtube id for embedding' do
+      expect(@media.trailer_id).to eq('5NpEA2yaWVQ')
+    end
+  end
 end


### PR DESCRIPTION
Partially complete media details page

# Summary of things changed:
Added checks for attributes before rendering on media details and search
Add a trailer_id method to media poro to etract youtube id from youtube trailer link
Add iframe for embedded youtube trailer
Made posters on search results also link to media show page
Add message if not avail on any streaming subscription service

# List any known issues (include relevant code snippets): 
  - None

# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Screenshots of any new or changed FE views:

![Screen Shot 2023-03-01 at 11 36 12 AM](https://user-images.githubusercontent.com/54966635/222233819-71a9c9ad-8a78-49e6-bd3c-3ddd76528233.png)
