### PR TITLE
Visitor drop down button

### DIFF
--- a/app/views/media/show.html.erb
+++ b/app/views/media/show.html.erb
@@ -14,7 +14,7 @@
             </div>
             <%= render partial: 'shared/drop_down_lists', locals: { user_id: @user.id, media_id: @media.id, button_text: "Add to List"}  %>
           <% else %>
-            Login/Register to add this to a list.
+            <%= render partial: 'shared/visitor_drop_down', locals: { button_text: "Add to List" } %>
           <% end %>
         </div>
     </div>
@@ -35,7 +35,7 @@
     <% if @media.rating %>
       Rating: <%= @media.rating %>
       <br>
-      <% end %>
+    <% end %>
     <br>
     <% if @media.sub_services.present? %>
       Available for Streaming on: <%= @media.sub_services %>

--- a/app/views/shared/_media_result.html.erb
+++ b/app/views/shared/_media_result.html.erb
@@ -8,6 +8,6 @@
     <% if current_user %>
       <%= render partial: 'shared/drop_down_lists', locals: { user_id: current_user, media_id: media.id, button_text: ""} %>
     <% else %>
-      Login/Register to add this to a list.
+      <%= render partial: 'shared/visitor_drop_down', locals: { button_text: "Add to List" } %>
     <% end %>
   </div>

--- a/app/views/shared/_visitor_drop_down.html.erb
+++ b/app/views/shared/_visitor_drop_down.html.erb
@@ -1,0 +1,8 @@
+<div class="dropdown">
+  <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= button_text %> <span class="caret"></span>
+  </button>
+  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+    <li><%= link_to "Login to add this to a list", root_path, class: "dropdown-item", method: :get %></li>
+  </div>
+</div>

--- a/spec/features/media/show_spec.rb
+++ b/spec/features/media/show_spec.rb
@@ -55,10 +55,17 @@ RSpec.describe 'The Media Show page', :vcr, type: :feature do
     end
 
     describe 'as a visitor' do
-      it 'does not have option to add media to lists' do
+      it 'displays a button to add media to list but prompts visitor to login first' do 
         within '#add_to_list' do
-          expect(page).to have_content('Login/Register to add this to a list.')
-          expect(page).to_not have_button("Add to List")
+          expect(page).to have_content("Add to List")
+
+          click_button "Add to List"
+
+          expect(page).to have_link("Login to add this to a list")
+
+          click_link "Login to add this to a list"
+          
+          expect(current_path).to eq(root_path)
         end
       end
     end

--- a/spec/features/search/index_spec.rb
+++ b/spec/features/search/index_spec.rb
@@ -50,4 +50,25 @@ RSpec.describe 'Media Search' do
       end
     end
   end 
+
+  describe 'visitor' do 
+    it 'displays a button to add media to list but prompts visitor to login first' do 
+      visit root_path
+
+      fill_in "query", with: "bad"
+      click_button "Search"
+
+      within "#media_3173903" do 
+        expect(page).to have_content("Add to List")
+
+        click_button "Add to List"
+
+        expect(page).to have_link("Login to add this to a list")
+
+        click_link "Login to add this to a list"
+        
+        expect(current_path).to eq(root_path)
+      end
+    end
+  end
 end

--- a/spec/fixtures/vcr_cassettes/The_Media_Show_page/it_displays_media_data/as_a_visitor/displays_a_button_to_add_media_to_list_but_prompts_visitor_to_login_first.yml
+++ b/spec/fixtures/vcr_cassettes/The_Media_Show_page/it_displays_media_data/as_a_visitor/displays_a_button_to_add_media_to_list_but_prompts_visitor_to_login_first.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/api/v1/media/3173903?user_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"4e3872dca8671a76d55731c380a0de67"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1de1af8c-0473-488f-be0b-e1a7c4a71977
+      X-Runtime:
+      - '0.535145'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"3173903","type":"media","attributes":{"id":3173903,"title":"Breaking
+        Bad","audience_score":9.3,"rating":"TV-MA","media_type":"tv_series","description":"When
+        Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III
+        cancer and given a prognosis of only two years left to live. He becomes filled
+        with a sense of fearlessness and an unrelenting desire to secure his family''s
+        financial future at any cost as he enters the dangerous world of drugs and
+        crime.","genres":[],"release_year":2008,"runtime":45,"language":"en","sub_services":["Netflix"],"poster":"https://cdn.watchmode.com/posters/03173903_poster_w185.jpg","imdb_id":"tt0903747","tmdb_id":1396,"tmdb_type":"tv","trailer":"https://www.youtube.com/watch?v=5NpEA2yaWVQ","user_lists":"None"}}}'
+  recorded_at: Thu, 02 Mar 2023 19:11:55 GMT
+- request:
+    method: get
+    uri: http://localhost:5000/api/v1/trending_media
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"1cdfd488cb923dd7c2b7a5417f117f24"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bbb3b2be-3584-436b-9725-da491b0ab565
+      X-Runtime:
+      - '0.218176'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"82856","type":"trending_media","attributes":{"id":82856,"title":"The
+        Mandalorian","poster_path":"/eU1i6eHXlzMOlEq0ku1Rzq7Y4wA.jpg","media_type":"tv","vote_average":8.475}},{"id":"937278","type":"trending_media","attributes":{"id":937278,"title":"A
+        Man Called Otto","poster_path":"/130H1gap9lFfiTF9iDrqNIkFvC9.jpg","media_type":"movie","vote_average":7.635}},{"id":"906221","type":"trending_media","attributes":{"id":906221,"title":"Magic
+        Mike''s Last Dance","poster_path":"/5C9rerMqV1X0jnRdbbsM1BswVI2.jpg","media_type":"movie","vote_average":6.777}}]}'
+  recorded_at: Thu, 02 Mar 2023 19:11:55 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Issue #61 

# Summary of things changed:
- Created a drop-down button for visitors when they view media results or media show page. The button prompts visitors to log in before adding media to a list and redirects them to the landing page upon clicking the drop-down button
- PR does not include additional styling

# List any known issues (include relevant code snippets): 
- None

# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Screenshots of any new or changed FE views:

![Screen Shot 2023-03-02 at 11 33 54 AM](https://user-images.githubusercontent.com/95988505/222532023-af73f96e-34f4-40cd-8c44-d17490a6d67f.jpg)
