### PR TITLE
Add links to show page for trending media.

### DIFF
--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -7,7 +7,6 @@ class UserFacade
 
   def self.edit_user(current_user, username)
     response = UserService.edit_user(current_user, username)
-    # require 'pry'; binding.pry
     if response[:data]
       User.new(response[:data])
     else

--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -57,4 +57,8 @@ class Media
   def trailer_id
     trailer.partition('=').last
   end
+
+  def watchmode_id
+    "#{@type}-#{@id}"
+  end
 end

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -7,7 +7,7 @@
         <% group.each do |media| %>
           <div class="col-lg-4">
           <div id="media_<%= media.id %>">
-            <h3><%= media.title %></h3>
+            <h3><%= link_to media.title, media_path(media.watchmode_id) %></h3>
             <img src=<%="https://image.tmdb.org/t/p/w500#{media.poster_path}"%>>
             <div class="lead">
               <p>Vote Average: <%= media.round_vote %></p>

--- a/spec/features/landing_spec.rb
+++ b/spec/features/landing_spec.rb
@@ -30,20 +30,35 @@ RSpec.describe 'Landing page', type: :feature do
         end
       end
 
-      it 'has a section for 3 recommended trending media' do 
-        visit root_path
-          
-        within "#trending_media" do 
-          expect(page).to have_content("Trending Now")
-          expect(page).to have_content("Die Hart the Movie")
-          expect(page).to have_content("We Have a Ghost")
-          expect(page).to have_content("Knock at the Cabin")
+      describe 'trending media' do
+        it 'has a section for 3 recommended trending media' do 
+          visit root_path
+            
+          within "#trending_media" do 
+            expect(page).to have_content("Trending Now")
+            expect(page).to have_content("Die Hart the Movie")
+            expect(page).to have_content("We Have a Ghost")
+            expect(page).to have_content("Knock at the Cabin")
+          end
+
+          within "#media_1077280" do 
+            expect(page).to have_content("Die Hart the Movie")
+            expect(page).to have_css("img[src='https://image.tmdb.org/t/p/w500/1EnBjTJ5utgT1OXYBZ8YwByRCzP.jpg']")
+            expect(page).to have_content("Vote Average: 6.3")
+          end
         end
 
-        within "#media_1077280" do 
-          expect(page).to have_content("Die Hart the Movie")
-          expect(page).to have_css("img[src='https://image.tmdb.org/t/p/w500/1EnBjTJ5utgT1OXYBZ8YwByRCzP.jpg']")
-          expect(page).to have_content("Vote Average: 6.3")
+        it 'has links to each trending media show page', :vcr do
+          visit root_path
+
+          within '#trending_media' do
+            expect(page).to have_link("Die Hart the Movie")
+            expect(page).to have_link("We Have a Ghost")
+            expect(page).to have_link("Knock at the Cabin")
+            click_link "We Have a Ghost"
+          end
+
+          expect(current_path).to eq media_path("movie-852096")
         end
       end
     end

--- a/spec/fixtures/vcr_cassettes/Landing_page/when_a_user_or_visitor/visits_the_root_path_it/trending_media/has_links_to_each_trending_media_show_page.yml
+++ b/spec/fixtures/vcr_cassettes/Landing_page/when_a_user_or_visitor/visits_the_root_path_it/trending_media/has_links_to_each_trending_media_show_page.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/api/v1/media/movie-852096?user_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"2b0431666520f4b6d0a525376366dcbf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - abffbaa7-7e9a-4793-9bd6-42b29f872e18
+      X-Runtime:
+      - '0.441900'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"1639606","type":"media","attributes":{"id":1639606,"title":"We
+        Have a Ghost","audience_score":6.4,"rating":"PG-13","media_type":"movie","description":null,"genres":[],"release_year":2023,"runtime":null,"language":"en","sub_services":["Netflix"],"poster":"https://cdn.watchmode.com/posters/01639606_poster_w185.jpg","imdb_id":"tt7798604","tmdb_id":852096,"tmdb_type":"movie","trailer":"https://www.youtube.com/watch?v=qRcEeyyeXpY","user_lists":"None","user_rating":null}}}'
+  recorded_at: Fri, 03 Mar 2023 00:52:47 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Issue #62

# Summary of things changed:
Add links to landing page for trending media to media show page.

# List any known issues (include relevant code snippets): 
  - None

# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Screenshots of any new or changed FE views:
![Screen Shot 2023-03-02 at 6 56 44 PM](https://user-images.githubusercontent.com/33361274/222604794-639aef1d-a814-4a52-8c24-3ec651736bc0.png)

